### PR TITLE
add config for spot price

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -400,6 +400,7 @@ resource "aws_launch_configuration" "lc" {
   iam_instance_profile = aws_iam_instance_profile.instance_profile.name
   security_groups      = [aws_security_group.sg.id]
   user_data            = local.user_data
+  spot_price           = var.spot_price
 
   # Note: Required if deployed in a public subnet
   associate_public_ip_address = var.associate_public_ip_address
@@ -425,8 +426,8 @@ module "tags" {
 resource "aws_autoscaling_group" "asg" {
   name = var.name
 
-  max_size = 1
-  min_size = 1
+  max_size = var.max_size
+  min_size = var.min_size
 
   launch_configuration = aws_launch_configuration.lc.name
 

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,24 @@ variable "instance_type" {
   default     = "t3.micro"
 }
 
+variable "spot_price" {
+  description = "The maximum price to use for reserving spot instances. (Optional; Default: On-demand price)"
+  default     = ""
+  type        = string
+}
+
+variable "min_size" {
+  description = "The minimum number of servers in this server-group"
+  default     = 1
+  type        = number
+}
+
+variable "max_size" {
+  description = "The maximum number of servers in this server-group"
+  default     = 1
+  type        = number
+}
+
 variable "associate_public_ip_address" {
   description = "Whether to assign a public ip address to this instance"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -20,7 +20,7 @@ variable "instance_type" {
 }
 
 variable "spot_price" {
-  description = "The maximum price to use for reserving spot instances. (Optional; Default: On-demand price)"
+  description = "The maximum price to use for reserving spot instances. (Optional, use on demand instances if not set)"
   default     = ""
   type        = string
 }


### PR DESCRIPTION
Add the option to use spot instances. This could be useful if you want to reduce costs and you are ok with having some delays in the kinesis-to-S3 flow.